### PR TITLE
🚀 [FEAT/#102] npm Trusted Publisher 배포 워크플로 추가

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI/CD
+name: CI
 
 on:
   push:
@@ -7,19 +7,15 @@ on:
     branches: [master]
 
 jobs:
-  test-and-deploy:
+  build:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
-      packages: write
-      id-token: write
+      contents: read
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -38,79 +34,3 @@ jobs:
 
       - name: Run build
         run: pnpm build
-
-      - name: Setup Git config
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        run: |
-          git config --local user.email "tell280210@gmail.com"
-          git config --local user.name "Colbrush Bot"
-
-      - name: Analyze commits and auto version
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        run: |
-          COMMIT_COUNT=$(git rev-list --count HEAD)
-
-          if [ "$COMMIT_COUNT" -gt 10 ]; then
-            COMMITS=$(git log --pretty=format:"%s" HEAD~10..HEAD)
-          else
-            COMMITS=$(git log --pretty=format:"%s" HEAD)
-          fi
-
-          echo "Analyzing commits:"
-          echo "$COMMITS"
-
-          VERSION_TYPE="patch"  # default
-
-          # MAJOR 
-          if echo "$COMMITS" | grep -qiE "(BREAKING|💥)"; then
-            VERSION_TYPE="major"
-            echo "🚨 Breaking change detected - MAJOR version bump"
-          # MINOR
-          elif echo "$COMMITS" | grep -qiE "feat"; then
-            VERSION_TYPE="minor"
-            echo "✨ New feature detected - MINOR version bump"
-          # PATCH
-          elif echo "$COMMITS" | grep -qiE "fix"; then
-            VERSION_TYPE="patch"
-            echo "🐛 Bug fix detected - PATCH version bump"
-          # 기타 변경사항 (PATCH)
-          else
-            VERSION_TYPE="patch"
-            echo "📝 Other changes detected - PATCH version bump"
-          fi
-
-          # 현재 버전 확인
-          CURRENT_VERSION=$(node -p "require('./package.json').version")
-          echo "Current version: $CURRENT_VERSION"
-
-          # 자동 버전 업데이트
-          npm version $VERSION_TYPE --no-git-tag-version
-
-          # 새 버전 확인
-          NEW_VERSION=$(node -p "require('./package.json').version")
-          echo "New version: $NEW_VERSION"
-
-          # 변경사항 커밋
-          git add package.json
-          git commit -m "🔖 Auto bump $VERSION_TYPE version to v$NEW_VERSION" || exit 0
-
-          # Git 태그 생성
-          if git rev-parse "v${NEW_VERSION}" >/dev/null 2>&1; then
-            echo "Tag v${NEW_VERSION} already exists. Skipping tag creation."
-          else
-            git tag "v${NEW_VERSION}"
-            echo "✅ Created tag v${NEW_VERSION}"
-          fi
-
-          # 원격 저장소에 푸시 (태그 포함)
-          git push origin master --tags
-
-          # npm에 배포
-          echo "Publishing version $NEW_VERSION to npm..."
-          pnpm publish --no-git-checks
-
-          echo "✅ Successfully published v$NEW_VERSION to npm!"
-
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -30,6 +32,28 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Bump version
+        run: |
+          git config --local user.email "tell280210@gmail.com"
+          git config --local user.name "Colbrush Bot"
+
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+          if [ -n "$LAST_TAG" ]; then
+            COMMITS=$(git log --pretty=format:"%s" "$LAST_TAG"..HEAD)
+          else
+            COMMITS=$(git log --pretty=format:"%s")
+          fi
+          VERSION_TYPE="patch"
+
+          if echo "$COMMITS" | grep -qiE "(BREAKING|💥)"; then
+            VERSION_TYPE="major"
+          elif echo "$COMMITS" | grep -qiE "feat"; then
+            VERSION_TYPE="minor"
+          fi
+
+          npm version "$VERSION_TYPE" -m "chore: bump version to v%s"
+          git push origin HEAD:master --follow-tags
 
       - name: Publish to npm
         run: npm publish --provenance

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,35 @@
+name: Publish npm
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.23.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Publish to npm
+        run: npm publish --provenance


### PR DESCRIPTION
## 🚀 Related Issue
Closes #102

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement

## 📝 Description
- npm Trusted Publisher 설정에 사용할 `publish-npm.yml` 워크플로를 추가했습니다.
- 기존 `main.yml`에서 `NPM_TOKEN` 기반 npm publish 로직을 제거했습니다.
- `main.yml`은 CI build만 수행하도록 정리했습니다.

## ✔️ Checklist
- [x] I've read the [Contributing Guide](CONTRIBUTING.md)
- [x] I have checked that I'm merging into the correct branch (not `master` by mistake)
- [x] I have tested these changes locally and they work without errors
- [x] I have run `pnpm build` and it completes successfully
- [x] I have run `pnpm lint` and there are no linting errors
- [x] I have added/updated tests if needed
- [x] I have updated documentation if needed

## 📸 Screenshots (Optional)

## 💬 Review Notes (Optional)