### PR TITLE
🚀 [FEAT/#102] npm Trusted Publisher 배포 자동화

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,6 +1,8 @@
 name: Publish npm
 
 on:
+  push:
+    branches: [master]
   workflow_dispatch:
 
 permissions:
@@ -10,7 +12,12 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: >-
+      github.ref == 'refs/heads/master' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        startsWith(github.event.head_commit.message, 'chore: bump version') == false
+      )
 
     steps:
       - name: Checkout code

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -60,7 +60,9 @@ jobs:
           fi
 
           npm version "$VERSION_TYPE" -m "chore: bump version to v%s"
-          git push origin HEAD:master --follow-tags
 
       - name: Publish to npm
         run: npm publish --provenance
+
+      - name: Push version commit and tag
+        run: git push origin HEAD:master --follow-tags


### PR DESCRIPTION
## 🚀 Related Issue
Closes #102

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement

## 📝 Description
- npm Trusted Publisher 설정에 사용할 `publish-npm.yml` 워크플로를 추가했습니다.
- `master` push 시 자동으로 버전 bump 후 npm 배포가 실행되도록 구성했습니다.
- 기존 `main.yml`에서는 `NPM_TOKEN` 기반 publish 로직을 제거하고 CI build만 남겼습니다.
- npm publish가 성공한 뒤에만 version commit/tag를 `master`에 push하도록 배포 순서를 조정했습니다.

## ✔️ Checklist
- [x] I've read the [Contributing Guide](CONTRIBUTING.md)
- [x] I have checked that I'm merging into the correct branch (not `master` by mistake)
- [x] I have tested these changes locally and they work without errors
- [x] I have run `pnpm build` and it completes successfully
- [x] I have run `pnpm lint` and there are no linting errors
- [x] I have added/updated tests if needed
- [x] I have updated documentation if needed

## 📸 Screenshots (Optional)

## 💬 Review Notes (Optional)
npm Trusted Publisher 설정값은 아래와 같습니다.

- Publisher: GitHub Actions
- Organization/user: `2025-OSDC`
- Repository: `colbrush`
- Workflow filename: `publish-npm.yml`
- Environment name: 비워두기
- Allowed actions: `Allow npm publish`

`publish-npm.yml`은 `master` push에서만 publish를 실행합니다. 버전 bump 커밋으로 인한 재실행은 workflow 조건에서 제외했습니다.